### PR TITLE
fix(scheduler): 调整调度器线程池大小

### DIFF
--- a/cronjob-scheduler/src/main/java/cn/horace/cronjob/scheduler/starter/SchedulerStarter.java
+++ b/cronjob-scheduler/src/main/java/cn/horace/cronjob/scheduler/starter/SchedulerStarter.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class SchedulerStarter implements InitializingBean {
     private static final Logger logger = LoggerFactory.getLogger(SchedulerStarter.class);
-    private GracefulScheduledThreadPoolExecutor threadScheduledExecutor = new GracefulScheduledThreadPoolExecutor(11, new DefaultThreadFactory("scheduler-thread"), false);
+    private GracefulScheduledThreadPoolExecutor threadScheduledExecutor = new GracefulScheduledThreadPoolExecutor(12, new DefaultThreadFactory("scheduler-thread"), false);
     @Resource
     private AppConfig appConfig;
     @Resource


### PR DESCRIPTION
- 将调度器线程池核心线程数从11增加到12，当11个线程都被占用时，第12个任务需要等待其他任务完成后才能执行，可能导致任务无法按时执行，并且部分定时任务可能无法按照预定的时间间隔准时执行，影响系统的实时性和准确性